### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  pull_request:
+  push:
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+      - name: Install sbt
+        run: curl -Ls https://git.io/sbt > ./sbt && chmod 0755 ./sbt
+      - name: Prepare cache
+        uses: coursier/cache-action@v6
+      - name: Test
+        run: ./sbt test


### PR DESCRIPTION
- [Travis CI (org)](https://travis-ci.org) already had shut down 😇 
    - >  Since June 15th, 2021, the building on travis-ci.org is ceased.
- So I added GitHub Actions as new CI service instead of Travis CI
- My example result: https://github.com/y-yu/strymonas/actions/runs/1044122434